### PR TITLE
Added benchmark project and BenchmarkDotNet dependency to solution.

### DIFF
--- a/MathSharp.Benchmarks/MathSharp.Benchmarks.csproj
+++ b/MathSharp.Benchmarks/MathSharp.Benchmarks.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/MathSharp.Benchmarks/Program.cs
+++ b/MathSharp.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace MathSharp.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/MathSharp.sln
+++ b/MathSharp.sln
@@ -55,6 +55,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5E19EDF5
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MathSharp.UnitTests", "tests\MathSharp.UnitTests\MathSharp.UnitTests.csproj", "{8FFF4DEA-FF68-4C22-8C53-E911D1B47837}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MathSharp.Benchmarks", "MathSharp.Benchmarks\MathSharp.Benchmarks.csproj", "{D98072C3-F9B9-4B5D-ACD5-BC1F7A14F4B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{8FFF4DEA-FF68-4C22-8C53-E911D1B47837}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FFF4DEA-FF68-4C22-8C53-E911D1B47837}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FFF4DEA-FF68-4C22-8C53-E911D1B47837}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D98072C3-F9B9-4B5D-ACD5-BC1F7A14F4B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D98072C3-F9B9-4B5D-ACD5-BC1F7A14F4B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D98072C3-F9B9-4B5D-ACD5-BC1F7A14F4B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D98072C3-F9B9-4B5D-ACD5-BC1F7A14F4B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
[IMPL] Adding a performance project to MathSharp

The MathSharp solution has been updated with a Benchmarks project. In this project, it's possible to organically add benchmarks with the help of BenchmarkDotNet (direct dependency of the Benchmarks project).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/john-h-k/mathsharp/41)
<!-- Reviewable:end -->
