### PR TITLE
Fix for VectorDouble Trigonometry

### DIFF
--- a/sources/MathSharp/Vector/VectorFloatingPoint/VectorDouble/Logical.cs
+++ b/sources/MathSharp/Vector/VectorFloatingPoint/VectorDouble/Logical.cs
@@ -15,9 +15,9 @@ namespace MathSharp
         [MethodImpl(MaxOpt)]
         public static Vector256<double> Permute(Vector4DParam1_3 vector, byte control)
         {
-            if (Avx.IsSupported)
+            if (Avx2.IsSupported)
             {
-                return Avx.Permute(vector, control);
+                return Avx2.Permute4x64(vector, control);
             }
 
             return Shuffle(vector, vector, control);
@@ -42,10 +42,11 @@ namespace MathSharp
         [MethodImpl(MaxOpt)]
         public static Vector256<double> Shuffle(Vector4DParam1_3 left, Vector4DParam1_3 right, byte control)
         {
-            if (Avx.IsSupported)
-            {
-                return Avx.Shuffle(left, right, control);
-            }
+            //There is a way to do Permute4x64 with a few AVX instructions but haven't figured it out yet
+            //if (Avx.IsSupported)
+            //{
+            //    return Avx.Shuffle(left, right, control);
+            //}
 
             return Shuffle_Software(left, right, control);
         }

--- a/sources/MathSharp/Vector/VectorFloatingPoint/VectorDouble/Trigonometry.cs
+++ b/sources/MathSharp/Vector/VectorFloatingPoint/VectorDouble/Trigonometry.cs
@@ -17,9 +17,6 @@ namespace MathSharp
         private static readonly Vector256<double> SinCoefficient1D = Vector256.Create(-2.3889859e-08d, -0.16665852d, +0.0083139502d, -0.00018524670d);
         private const double SinCoefficient1DScalar = -2.3889859e-08d;
 
-        private const string DoNotUse = "DO NOT USE!! Double precision trig is currently non-working";
-
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static Vector256<double> Sin(Vector4DParam1_3 vector)
         {
@@ -74,7 +71,6 @@ namespace MathSharp
             }
         }
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static Vector256<double> SinApprox(Vector4DParam1_3 vector)
         {
@@ -117,7 +113,6 @@ namespace MathSharp
         private static readonly Vector256<double> CosCoefficient1D = Vector256.Create(-2.6051615e-07d, -0.49992746d, +0.041493919d, -0.0012712436d);
         private const double CosCoefficient1DScalar = -2.6051615e-07d;
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static Vector256<double> Cos(Vector4DParam1_3 vector)
         {
@@ -175,7 +170,6 @@ namespace MathSharp
             }
         }
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static Vector256<double> CosApprox(Vector4DParam1_3 vector)
         {
@@ -220,8 +214,7 @@ namespace MathSharp
         private static readonly Vector256<double> TanCoefficients0D = Vector256.Create(1.0d, -4.667168334e-1d, 2.566383229e-2d, -3.118153191e-4d);
         private static readonly Vector256<double> TanCoefficients1D = Vector256.Create(4.981943399e-7d, -1.333835001e-1d, 3.424887824e-3d, -1.786170734e-5d);
         private static readonly Vector256<double> TanConstantsD = Vector256.Create(1.570796371d, 6.077100628e-11d, 0.000244140625d, 0.63661977228d);
-        
-        [Obsolete(DoNotUse, true)]
+
         [MethodImpl(MaxOpt)]
         public static Vector256<double> Tan(Vector4DParam1_3 vector)
         {
@@ -299,7 +292,6 @@ namespace MathSharp
             }
         }
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         private static Vector256<long> CompareBitwiseEqualInt64(Vector256<long> left, Vector256<long> right)
         {
@@ -321,9 +313,8 @@ namespace MathSharp
             }
         }
 
-        private static readonly Vector256<double> TanEstCoefficientsD = Vector256.Create(2.484d, -1.954923183e-1d, 2.467401101d, ScalarDoubleConstants.OneDivPi);
-        
-        [Obsolete(DoNotUse, true)]
+        private static readonly Vector256<double> TanEstCoefficientsD = Vector256.Create(2.484d, -1.954923183e-1d, 2.467401101d, ScalarDoubleConstants.OneDivPi);        
+
         [MethodImpl(MaxOpt)]
         public static Vector256<double> TanApprox(Vector4DParam1_3 vector)
         {
@@ -354,7 +345,6 @@ namespace MathSharp
             return Tan(vector);
         }
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static void SinCos(Vector4DParam1_3 vector, out Vector256<double> sin, out Vector256<double> cos)
         {
@@ -432,7 +422,6 @@ namespace MathSharp
             }
         }
 
-        [Obsolete(DoNotUse, true)]
         [MethodImpl(MaxOpt)]
         public static void SinCosApprox(Vector4DParam1_3 vector, out Vector256<double> sin, out Vector256<double> cos)
         {


### PR DESCRIPTION
`_mm_permute_ps` is not equivalent to `_mm256_permute_pd` whereas `_mm256_permute4x64_pd` is.

The shuffle fallback had to be disabled due to a similar issue. (See comment)